### PR TITLE
finishAgentWork support and initial Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+bin
+build
+Dockerfile
+README.md
+codecov.yml
+.git
+*/**/generated

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:bullseye-slim as base
+
+USER root
+
+#runtime dependencies
+RUN apt update && apt --no-install-recommends -y install python3-pip python3 libpython3-dev curl net-tools
+
+#Libs required in runtime
+RUN apt --no-install-recommends -y install file libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libglib2.0-0 nlohmann-json3-dev libwebsocketpp-dev tini
+
+#Installing python runtime deps for sc-machine
+RUN python3 -m pip install --no-cache-dir termcolor tornado websocket-client
+
+
+#Derived from debian and not "base" image because any change in base would cache bust the build environment
+FROM debian:bullseye-slim AS buildenv
+ENV CCACHE_DIR=/ccache
+#Install build-time deps
+RUN apt update && apt -y install git file libglib2.0-dev ccache libboost-system-dev libboost-filesystem-dev libboost-program-options-dev make cmake antlr gcc g++ llvm libcurl4-openssl-dev libclang-dev curl python3-dev python3-pip nlohmann-json3-dev libwebsocketpp-dev
+
+## copy sources
+WORKDIR /scn-editor
+COPY . .
+
+#Building sc-machine
+RUN --mount=type=cache,target=/ccache/ cmake -B build && cmake --build build -j$(nproc)
+
+#Gathering all artifacts together
+FROM base AS final
+COPY --from=buildenv /scn-editor/scn-editor.ini /scn-editor/scn-editor.ini
+COPY --from=buildenv /scn-editor/kb /scn-editor/kb
+COPY --from=buildenv /scn-editor/bin /scn-editor/bin
+COPY --from=buildenv /scn-editor/problem-solver/sc-machine/scripts /scn-editor/problem-solver/sc-machine/scripts
+
+EXPOSE 8090
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/scn-editor/problem-solver/sc-machine/scripts/docker_entrypoint.sh"]
+CMD ["serve"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  problem-solver:
+    labels:
+      "autoheal": "true"
+    image: scn-editor/problem-solver
+    build: 
+      context: .
+    restart: unless-stopped
+    ports:
+      - "8090:8090"
+    volumes:
+      - kb-binary:/scn-editor/kb.bin
+    environment:
+      - "REBUILD_KB=0"
+      - "BINARY_PATH=/scn-editor/bin"
+      - "CONFIG_PATH=/scn-editor/scn-editor.ini"
+      - "KB_PATH=/scn-editor/kb"
+    healthcheck:
+      test: "python3 /scn-editor/problem-solver/sc-machine/scripts/healthcheck.py"
+      interval: 2s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+
+volumes:
+  kb-binary: {}

--- a/problem-solver/cxx/commonModule/searchSemNeighborhoodAgent/searchSemNeighborhoodAgent.cpp
+++ b/problem-solver/cxx/commonModule/searchSemNeighborhoodAgent/searchSemNeighborhoodAgent.cpp
@@ -18,6 +18,7 @@ SC_AGENT_IMPLEMENTATION(searchSemNeighborhoodAgent) {
   ScAddr rootNode = utils::IteratorUtils::getAnyByOutRelation(&m_memoryCtx, questionNode, scAgentsCommon::CoreKeynodes::rrel_1);
   if (!rootNode.IsValid()) {
     SC_LOG_ERROR("searchSemNeighborhoodAgent: Invalid ScAddr");
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
     return SC_RESULT_ERROR;
   }
 
@@ -33,6 +34,7 @@ SC_AGENT_IMPLEMENTATION(searchSemNeighborhoodAgent) {
   ScTemplateGenResult result;
   if (!m_memoryCtx.HelperGenTemplate(templ, result)) {
     SC_LOG_ERROR("searchSemNeighborhoodAgent: Failed to generate answer node");
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
     return SC_RESULT_ERROR;
   }
 
@@ -42,7 +44,7 @@ SC_AGENT_IMPLEMENTATION(searchSemNeighborhoodAgent) {
   m_memoryCtx.CreateEdge(ScType::EdgeAccessConstPosPerm, result[2], rootNode);
 
   SC_LOG_INFO("searchSemNeighborhoodAgent: Answer generated");
-  
+  utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, result[2], true);
   return SC_RESULT_OK;
 }
 

--- a/problem-solver/cxx/scnEditorModule/addToScnPageAgent/addToScnPageAgent.cpp
+++ b/problem-solver/cxx/scnEditorModule/addToScnPageAgent/addToScnPageAgent.cpp
@@ -17,7 +17,8 @@ SC_AGENT_IMPLEMENTATION(addToScnPageAgent) {
 
   ScAddr const& elt = utils::IteratorUtils::getAnyByOutRelation(&m_memoryCtx, questionNode, scAgentsCommon::CoreKeynodes::rrel_1);
   if (!elt.IsValid()) {
-    return SC_RESULT_OK;
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
+    return SC_RESULT_ERROR_INVALID_PARAMS;
   }
   ScAddr const& curPage = utils::IteratorUtils::getAnyByOutRelation(&m_memoryCtx, addToScnPageKeynodes::scn_editor, addToScnPageKeynodes::rrel_current_scn_page);
   

--- a/problem-solver/cxx/scnEditorModule/createScnPageAgent/createScnPageAgent.cpp
+++ b/problem-solver/cxx/scnEditorModule/createScnPageAgent/createScnPageAgent.cpp
@@ -32,6 +32,7 @@ SC_AGENT_IMPLEMENTATION(createScnPageAgent) {
     m_memoryCtx.GetLinkContent(pageName, pageIdtf);
     if (m_memoryCtx.HelperResolveSystemIdtf(pageIdtf).IsValid()) {
       SC_LOG_ERROR("createScnPageAgent: Element with given system identifier already exists");
+      utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
       return SC_RESULT_ERROR;
     }
   }
@@ -48,6 +49,7 @@ SC_AGENT_IMPLEMENTATION(createScnPageAgent) {
   ScTemplateGenResult result;
   if (!m_memoryCtx.HelperGenTemplate(templ, result)) {
     SC_LOG_ERROR("createScnPageAgent: Failed to create new sc.n-page");
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
     return SC_RESULT_ERROR;
   }
 
@@ -61,7 +63,7 @@ SC_AGENT_IMPLEMENTATION(createScnPageAgent) {
     ScAddr action = selectScnPageAgent::prepareActionInit(&m_memoryCtx, result[2]);
     utils::AgentUtils::getActionResultIfExists(&m_memoryCtx, action, 400);
   }
-
+  utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, result[2], true);
   return SC_RESULT_OK;
 }
 

--- a/problem-solver/cxx/scnEditorModule/deleteScnPageAgent/deleteScnPageAgent.cpp
+++ b/problem-solver/cxx/scnEditorModule/deleteScnPageAgent/deleteScnPageAgent.cpp
@@ -18,6 +18,7 @@ SC_AGENT_IMPLEMENTATION(deleteScnPageAgent) {
   ScAddr page = utils::IteratorUtils::getAnyByOutRelation(&m_memoryCtx, questionNode, scAgentsCommon::CoreKeynodes::rrel_1);
   if (!page.IsValid()) {
     SC_LOG_ERROR("deleteScnPageAgent: No such sc.n-page");
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
     return SC_RESULT_ERROR;
   }
 
@@ -40,7 +41,7 @@ SC_AGENT_IMPLEMENTATION(deleteScnPageAgent) {
   }
 
   SC_LOG_INFO("deleteScnPageAgent: sc.n-page deleted successfully");
-
+  utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, true);
   return SC_RESULT_OK;
 }
 

--- a/problem-solver/cxx/scnEditorModule/openScnPageAgent/openScnPageAgent.cpp
+++ b/problem-solver/cxx/scnEditorModule/openScnPageAgent/openScnPageAgent.cpp
@@ -19,6 +19,7 @@ SC_AGENT_IMPLEMENTATION(openScnPageAgent) {
   ScAddr const& scnRootNode = utils::IteratorUtils::getAnyByOutRelation(&m_memoryCtx, questionNode, scAgentsCommon::CoreKeynodes::rrel_1);
   if (!scnRootNode.IsValid()) {
     SC_LOG_ERROR("openScnPageAgent: Invalid ScAddr");
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
     return SC_RESULT_ERROR;
   }
 
@@ -31,7 +32,7 @@ SC_AGENT_IMPLEMENTATION(openScnPageAgent) {
   ScAddr answer = utils::IteratorUtils::getAnyByOutRelation(&m_memoryCtx, action, scAgentsCommon::CoreKeynodes::nrel_answer);
 
   ScTemplate templ;
-  templ.TripleWithRelation(
+  templ.Quintuple(
     openScnPageKeynodes::scn_editor,
     ScType::EdgeAccessVarPosPerm,
     answer,
@@ -42,6 +43,7 @@ SC_AGENT_IMPLEMENTATION(openScnPageAgent) {
   ScTemplateGenResult result;
   if (!m_memoryCtx.HelperGenTemplate(templ, result)) {
     SC_LOG_ERROR("openScnPageAgent: Failed to create new sc.n-page");
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
     return SC_RESULT_ERROR;
   }
   
@@ -49,7 +51,7 @@ SC_AGENT_IMPLEMENTATION(openScnPageAgent) {
   utils::AgentUtils::getActionResultIfExists(&m_memoryCtx, action, 400);
 
   SC_LOG_INFO("openScnPageAgent: new sc.n-page opened successfully");
-  
+  utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, result[2], true);
   return SC_RESULT_OK;
 }
 

--- a/problem-solver/cxx/scnEditorModule/removeFromScnPageAgent/removeFromScnPageAgent.cpp
+++ b/problem-solver/cxx/scnEditorModule/removeFromScnPageAgent/removeFromScnPageAgent.cpp
@@ -17,7 +17,7 @@ SC_AGENT_IMPLEMENTATION(removeFromScnPageAgent) {
 
   ScAddr elt = utils::IteratorUtils::getAnyByOutRelation(&m_memoryCtx, questionNode, scAgentsCommon::CoreKeynodes::rrel_1);
   if (!elt.IsValid()) {
-    return SC_RESULT_OK;
+    return SC_RESULT_ERROR;
   }
 
   if (m_memoryCtx.GetElementType(elt).IsLink()) {
@@ -29,6 +29,7 @@ SC_AGENT_IMPLEMENTATION(removeFromScnPageAgent) {
   ScAddr curPage = utils::IteratorUtils::getAnyByOutRelation(&m_memoryCtx, removeFromScnPageKeynodes::scn_editor, removeFromScnPageKeynodes::rrel_current_scn_page);
   if (!m_memoryCtx.HelperCheckEdge(curPage, elt, ScType::EdgeAccessConstPosPerm)) {
     SC_LOG_ERROR("removeFromScnPageAgent: Given element is not on current page");
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
     return SC_RESULT_ERROR;
   }
   
@@ -70,7 +71,7 @@ SC_AGENT_IMPLEMENTATION(removeFromScnPageAgent) {
   }
 
   SC_LOG_INFO("removeFromScnPageAgent: Successfully removed element from sc.n-page");
-
+  utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, true);
   return SC_RESULT_OK;
 }
 

--- a/problem-solver/cxx/scnEditorModule/selectScnPageAgent/selectScnPageAgent.cpp
+++ b/problem-solver/cxx/scnEditorModule/selectScnPageAgent/selectScnPageAgent.cpp
@@ -1,6 +1,6 @@
 #include "sc-agents-common/utils/IteratorUtils.hpp"
 #include "sc-agents-common/keynodes/coreKeynodes.hpp"
-
+#include "sc-agents-common/utils/AgentUtils.hpp"
 #include "selectScnPageKeynodes.hpp"
 
 #include "selectScnPageAgent.hpp"
@@ -40,6 +40,7 @@ SC_AGENT_IMPLEMENTATION(selectScnPageAgent) {
   );
   if (!testOnScnPage->Next()) {
     SC_LOG_ERROR("selectScnPageAgent: Given node is not an sc.n-page");
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, false);
     return SC_RESULT_ERROR;
   }
 
@@ -54,7 +55,7 @@ SC_AGENT_IMPLEMENTATION(selectScnPageAgent) {
   }
 
   SC_LOG_INFO("selectScnPageAgent: New current sc.n-page selected successfully");
-  
+    utils::AgentUtils::finishAgentWork(&m_memoryCtx, questionNode, newCurScnPage, false);
   return SC_RESULT_OK;
 }
 


### PR DESCRIPTION
This change allows `ts-sc-client` to subscribe for events in `sc-memory` that indicate the state of the initiated question. Required for [scn-editor-ui](https://github.com/FallenChromium/scn-editor-ui)